### PR TITLE
Add / after codelab URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build an AngularDart & Firebase Web App - Final app
-AngularDart and Firebase code lab source code.
+AngularDart and Firebase codelab source code.
 
-* **Code lab**: https://codelabs.developers.google.com/codelabs/angulardart-firebase-web-app
-* **Code lab steps**: https://github.com/Janamou/firebase-counter-steps
+* **Codelab**: https://codelabs.developers.google.com/codelabs/angulardart-firebase-web-app/
+* **Codelab steps**: https://github.com/Janamou/firebase-counter-steps
 * **Try it**: https://janamou.github.io/firebase-counter/


### PR DESCRIPTION
It works for the owner without the /, but not for others. (You can test using an incognito window.)

(Also, "codelab" is now officially one word.)